### PR TITLE
Compilation on MacOS

### DIFF
--- a/src/smw_0c.c
+++ b/src/smw_0c.c
@@ -108,7 +108,7 @@ void BufferCreditsBackgrounds() {  // 0c93dd
     BufferCreditsBackgrounds_0C94C0();
     ++*(uint16 *)&blocks_screen_to_place_current_object;
   } while (*(uint16 *)&blocks_screen_to_place_current_object != 7);
-  strcpy((int8 *)&temp65, "@X");
+  strcpy((char *)&temp65, "@X");
   blocks_screen_to_place_current_object = 0;
   UpdateCreditsBackground();
   InitializeCreditsEggPositions();

--- a/src/snes/snes.c
+++ b/src/snes/snes.c
@@ -211,7 +211,7 @@ void snes_runCycle(Snes* snes) {
 
   snes_handle_pos_stuff(snes);
  }
-#define IS_ADR(x) (x == 33333333333)
+#define IS_ADR(x) (x == 333333UL)
 
 void snes_runCpu(Snes *snes) {
   uint32_t pc = snes->cpu->k << 16 | snes->cpu->pc;

--- a/src/variables.h
+++ b/src/variables.h
@@ -84,7 +84,7 @@
 #define camera_last_screen_horiz (*(uint8*)(g_ram+0x5E))
 #define camera_last_screen_vert (*(uint8*)(g_ram+0x5F))
 #define sprites_tile_priority (*(uint8*)(g_ram+0x64))
-#define temp65 (*(uint8*)(g_ram+0x65))
+#define temp65 (*(char*)(g_ram+0x65))
 #define temp66 (*(uint8*)(g_ram+0x66))
 #define temp67 (*(uint8*)(g_ram+0x67))
 #define ptr_layer2_data (*(uint16*)(g_ram+0x68))


### PR DESCRIPTION
Fixed two errors on MacOS:
```sh
src/snes/snes.c:484:9: error: result of comparison of constant 33333333333 with expression of type 'uint32_t' 
(aka 'unsigned int') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
```

```sh
error: passing 'int8 *' (aka 'signed char *') to parameter of type 'char *' converts between pointers to 
integer types where one is of the unique plain 'char' type and the other is not [-Werror,-Wpointer-sign] 
strcpy((int8 *)&temp65, "@X");
```

Both errors are NOT tested in Linux/Windows. Testing on both platforms should be good.

Also in macos the program doesn't launch by double-click but instead open a terminal inside the directory and then `./smw`. Creating an app macos image should work, but I thiink it's not worth the effort.
[Tip Jar](https://ko-fi.com/sbritorodr)