### PR TITLE
Move tcc instructions to readme

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,15 +55,6 @@ Download VS installer. On installer prompt, make sure you're on "Workloads" and 
 2. Change the build target from `Debug` to `Release`
 3. Build the solution.
 
-## Building with Tiny C Compiler
-
- Dependencies and requirements:
- * You'll need [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20230519/tcc_20230519.zip) and [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip) in order to compile using TCC.
-
-1. Unzip both TCC and SDL and place them in `third_party` folder.
-2. Double click `run_with_tcc.bat`
-3. Wait for it to compile and the game will automatically boot-up.
-
 # Linux/MacOS
 
 CD to your SM root folder and open the terminal and type:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Our discord server is: https://discord.gg/AJJbJAzNNJ
 
 Early version. It has bugs and the code is messy.
 
-For building instructions, see: https://github.com/snesrev/smw/blob/main/BUILDING.md
+You must self-build for now. Easy method on Windows (no installs, terminal, or big downloads):<br>
+(1) Click the green button "Code > Download ZIP" on the github page and extract the ZIP<br>
+(2) Place the USA rom named smw.sfc in that folder (crc32=b1ed489)<br>
+(3) Download [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20230519/tcc_20230519.zip) and [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip) and extract each ZIP into the "third-party" subfolder<br>
+(4) Double-click run_with_tcc.bat in the main dir. This will create smw.exe and run it.<br>
+(5) Configure with smw.ini<br>
 
-Put smw.sfc (sha1 hash 6b47bb75d16514b6a476aa0c73a683a2a4c18765) in the root folder. When running, it will run both versions and compare frame by frame. If it detects a mismatch, it saves a snapshot in saves/ and displays a counter on screen counting down from 300.
+For other platforms and compilers, see: https://github.com/snesrev/smw/blob/main/BUILDING.md
+
+When running, it runs an emulated version in the background and compares the ram state every frame. If it detects a mismatch, it saves a snapshot in saves/ and displays a counter on screen counting down from 300. Please submit these bug snapshots on discord so that they can be fixed.
 


### PR DESCRIPTION
Push tcc as default method for nabs and refer to building.md for less common platforms and other compilers. Also clarify "both versions" so it isn't misinterpreted as rom versions.