### PR TITLE
Overhaul the building instructions.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,9 +19,10 @@
  Dependencies and requirements:
  * You'll need [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20230519/tcc_20230519.zip) and [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip) in order to compile using TCC.
 
-1. Unzip both TCC and SDL and place them in `third_party` folder.
-2. Double click `run_with_tcc.bat`
-3. Wait for it to compile and the game will automatically boot-up.
+1. Rename your obtaind Super Mario World rom to `smw.sfc` and place it in the root folder.
+2. Unzip both TCC and SDL and place them in `third_party` folder.
+3. Double click `run_with_tcc.bat`
+4. Wait for it to compile and the game will automatically boot-up.
 
 # More advanced methods
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,7 +36,7 @@ Note: *Make sure you're using MINGW64 and you're in `smw` folder in the terminal
 
 1. Install MSYS2 on your machine.
 2. Place the copy of your rom in the main directory.
-3. Install the necessary dependencies by inputting this command in MSYS2 terminal:
+3. Install the necessary dependencies and SDL2 by inputting this command in MSYS2 terminal:
 
 ```sh
 pacman -S mingw-w64-x86_64-SDL2 && pacman -S make && pacman -S mingw-w64-x86_64-gcc

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,6 +72,14 @@ Dependencies and requirements:
   * Super Mario All-Stars rom (US version and not + Mario World)
   * `zstandard`
 
+1. In MSYS2 terminal, type `git checkout smb1` or `git checkout devel` to change the branches.
+2. Rename your obtained rom to `smas.sfc` and place it inside the `other` folder.
+3. To install `zstandard` make sure you've installed Python and added to PATH. Open up CMD and type `pip install zstandard` to install the required dep.
+4. In the `other` folder drag and drop your renamed rom into `extract.py` or by typing `extract.py` in the command line to extract the necessary files.
+5. Move `smb1.sfc` and `smbll.sfc` to root folder.
+6. Before running the games, make sure to recompile or else it won't boot up.
+7. Drag your desired game to `smw.exe` in order to run.
+
   
 # Linux/MacOS
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,7 +50,7 @@ pacman -S mingw-w64-x86_64-SDL2 && pacman -S make && pacman -S mingw-w64-x86_64-
 -LC:/msys64/mingw64/lib -lmingw32 -mwindows -lSDL2main -lSDL2
 ```
 
-After you've done installing everything, cd to `smw` folder. Type `make`
+After you've done installing everything, in the terminal, type `make`
 In order to speed up the compilation, type `make -j16`
 
 ## Building with Visual Studio

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,10 @@
-# Requirements
+# Welcome to the building instructions for the project! Please make sure to prepeare the required files and install the necessary dependencies for your current OS.
+
+# Requirements:
   * A Super Mario World rom (Make sure to rename it to `smw.sfc`)
-  * libsdl2-dev
+  * `libsdl2-dev` (The installation for this will be different for each compiler.)
   * Super Mario World repo `git clone --recursive https://github.com/snesrev/smw`
+  * [Python](https://www.python.org/) (During installation, make sure to check the "Add to PATH")
   
  For Linux/MacOS you must install these for your desired OS:
  * Ubuntu/Debian: `sudo apt install libsdl2-dev`
@@ -19,6 +22,8 @@
 1. Unzip both TCC and SDL and place them in `third_party` folder.
 2. Double click `run_with_tcc.bat`
 3. Wait for it to compile and the game will automatically boot-up.
+
+# More advanced methods
 
 ## Building with MSYS2
 
@@ -60,9 +65,17 @@ Download VS installer. On installer prompt, make sure you're on "Workloads" and 
 2. Change the build target from `Debug` to `Release`
 3. Build the solution.
 
+# Running SMB1 and SMBLL
+
+Dependencies and requirements:
+
+  * Super Mario All-Stars rom (US version and not + Mario World)
+  * `zstandard`
+
+  
 # Linux/MacOS
 
-CD to your SM root folder and open the terminal and type:
+Open the terminal and CD to your SM root folder:
 ```sh
 make
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,6 +11,15 @@
 
 # Windows
 
+## Building with Tiny C Compiler
+
+ Dependencies and requirements:
+ * You'll need [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20230519/tcc_20230519.zip) and [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip) in order to compile using TCC.
+
+1. Unzip both TCC and SDL and place them in `third_party` folder.
+2. Double click `run_with_tcc.bat`
+3. Wait for it to compile and the game will automatically boot-up.
+
 ## Building with MSYS2
 
 Dependencies and requirements:
@@ -22,7 +31,7 @@ Note: *Make sure you're using MINGW64 and you're in `smw` folder in the terminal
 
 1. Install MSYS2 on your machine.
 2. Place the copy of your rom in the main directory.
-3. Install the necessary dependencies by inputting this command in the terminal.
+3. Install the necessary dependencies by inputting this command in MSYS2 terminal:
 
 ```sh
 pacman -S mingw-w64-x86_64-SDL2 && pacman -S make && pacman -S mingw-w64-x86_64-gcc
@@ -34,10 +43,6 @@ pacman -S mingw-w64-x86_64-SDL2 && pacman -S make && pacman -S mingw-w64-x86_64-
 5. After that type `sdl2-config --libs`, should output:
 ```sh
 -LC:/msys64/mingw64/lib -lmingw32 -mwindows -lSDL2main -lSDL2
-```
-Also you need pkg-config
-```sh
-pacman -S pkg-config
 ```
 
 After you've done installing everything, cd to `smw` folder. Type `make`
@@ -54,15 +59,6 @@ Download VS installer. On installer prompt, make sure you're on "Workloads" and 
 1. Open `smw.sln` solution.
 2. Change the build target from `Debug` to `Release`
 3. Build the solution.
-
-## Building with Tiny C Compiler
-
- Dependencies and requirements:
- * You'll need [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20230519/tcc_20230519.zip) and [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip) in order to compile using TCC.
-
-1. Unzip both TCC and SDL and place them in `third_party` folder.
-2. Double click `run_with_tcc.bat`
-3. Wait for it to compile and the game will automatically boot-up.
 
 # Linux/MacOS
 
@@ -85,6 +81,7 @@ Dependencies and requirements:
   * The `switch-sdl2` library
   * [DevKitPro](https://github.com/devkitPro/installer)
   * [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere)
+  * `pk-config`
   
 1. Make sure you've installed Atmosphere on your Switch.
 2. Please download the DevKitPro version of MSYS2 through their installer, as the default MSYS2 causes issues with windows compiling.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@
  * You'll need [TCC](https://github.com/FitzRoyX/tinycc/releases/download/tcc_20230519/tcc_20230519.zip) and [SDL2](https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-devel-2.26.5-VC.zip) in order to compile using TCC.
 
 1. Rename your obtaind Super Mario World rom to `smw.sfc` and place it in the root folder.
-2. Unzip both TCC and SDL and place them in `third_party` folder.
+2. Unzip both TCC and SDL2 and place them in `third_party` folder.
 3. Double click `run_with_tcc.bat`
 4. Wait for it to compile and the game will automatically boot-up.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -77,7 +77,7 @@ Dependencies and requirements:
 3. To install `zstandard` make sure you've installed Python and added to PATH. Open up CMD and type `pip install zstandard` to install the required dep.
 4. In the `other` folder drag and drop your renamed rom into `extract.py` or by typing `extract.py` in the command line to extract the necessary files.
 5. Move `smb1.sfc` and `smbll.sfc` to root folder.
-6. Before running the games, make sure to recompile or else it won't boot up.
+6. Before running the games, make sure to recompile or else they won't boot up.
 7. Drag your desired game to `smw.exe` in order to run.
 
   


### PR DESCRIPTION
### Description

### <!-- What is the purpose of this PR and what it adds? -->
This PR overhauls the instructions (again) but this time I didn't do it during night nor when I am tired.
This PR includes:
  * Moving TCC above MSYS2.
  * Separated MSYS2 and VS from TCC and added them to *More advanced methods* 
  * Made everything more crystal clear and fixed confusion stated in Discord.
  * Removed `pkg-config` from MSYS2 and moved it to Switch instructions. The reason I did that is because when installing `pkg-config` it will be installed on the normal MSYS2 and ***Not devkitpro's version of MSYS2*** and compilation will fail on Windows using nomal MSYS2.
  * Added how to run SMB1 and SMBLL!

### Will this Pull Request break anything? 
Nope.

### Suggested Testing Steps
See if I have made any mistakes.
