### PR TITLE
Update smw_05.c

### DIFF
--- a/src/smw_05.c
+++ b/src/smw_05.c
@@ -1166,7 +1166,7 @@ uint8 UnusedOverworldEventPassedCheck(uint8 j) {  // 05b363
   return kBitTable_Bank05[j & 7] & ow_event_flags[j >> 3];
 }
 
-static const kLevelTileAnimationsAddrs[] = {
+static const uint16 kLevelTileAnimationsAddrs[] = {
   0x600, 0x640, 0x680,
   0x740, 0xEA0, 0x800,
   0x500, 0x540, 0x580,


### PR DESCRIPTION
resolve Werror=implicit-int

### Description
<!-- What is the purpose of this PR and what it adds? -->
compile without suppression flag.
`CFLAGS="-Wno-implicit-int" make`

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
fixes error:
```
src/smw_05.c:1169:14: error: type defaults to ‘int’ in declaration of ‘kLevelTileAnimationsAddrs’ [-Werror=implicit-int]
 1169 | static const kLevelTileAnimationsAddrs[] = {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~
```

### Suggested Testing Steps
<!-- See if the compiling fails/break anything in the game. -->
