### PR TITLE
Fix secondary entrances data extraction

### DIFF
--- a/assets/compile_resources.py
+++ b/assets/compile_resources.py
@@ -630,11 +630,11 @@ def print_all(args):
 
     add_asset_uint8('kLmLevelData5DC85', util.get_bytes(get_24(0x5DC86), 512) if lm_load_level else b'')    
     add_asset_uint8('kLmLevelData5DC8A', util.get_bytes(get_24(0x5DC8B), 512) if lm_load_level else b'')    
-    add_asset_uint8('kLm5FE00', util.get_bytes(get_24(0x5DC81), 512) if lm_load_level else b'')    
+    add_asset_uint8('kLm5FE00', util.get_bytes(get_24(0x5DC81), 512) if lm_load_level else util.get_bytes(0x5fe00, 0x200))
 
-    add_asset_uint8('kLevelInfo_05F800', util.get_bytes(get_24(0xde191), 0x200) if lm_load_level else b'')
-    add_asset_uint8('kLevelInfo_05FA00', util.get_bytes(get_24(0xde198), 0x200) if lm_load_level else b'')
-    add_asset_uint8('kLevelInfo_05FC00', util.get_bytes(get_24(0xde19f), 0x200) if lm_load_level else b'')
+    add_asset_uint8('kLevelInfo_05F800', util.get_bytes(get_24(0xde191), 0x200) if lm_load_level else util.get_bytes(0x5f800, 0x200))
+    add_asset_uint8('kLevelInfo_05FA00', util.get_bytes(get_24(0xde198), 0x200) if lm_load_level else util.get_bytes(0x5fa00, 0x200))
+    add_asset_uint8('kLevelInfo_05FC00', util.get_bytes(get_24(0xde19f), 0x200) if lm_load_level else util.get_bytes(0x5fc00, 0x200))
     lm_feat.flags |= kLmFeature_LoadLevel if lm_load_level else 0
 
   add_load_level_stuff()


### PR DESCRIPTION
### Description
This PR fixes extraction of the "secondary entrances" data in the python script. Since the support of LM was added, secondary entrances data in range `0x5f800-0x5ffff` are ignored, which results in transitioning to a broken "bonus level" whenever mario enters a pipe that should bring him back to the main level.

### Will this Pull Request break anything? 
No.

### Suggested Testing Steps
- Run game with `g_runmode = RM_MINE`
- Enter level Yoshi's Island 1
- Enter the 2nd blue pipe (under two yellow blocks)
- Enter the pipe to go back to the main part of the level
- Before fix: you get directed to a broken bonus level
- After fix: you get back to the correct position, being shot out of a pipe in the main part of the level
